### PR TITLE
allows user to custom display domain class property label in view

### DIFF
--- a/grails-app/services/net/kaleidos/plugins/admin/renderer/GrailsAdminPluginHtmlRendererService.groovy
+++ b/grails-app/services/net/kaleidos/plugins/admin/renderer/GrailsAdminPluginHtmlRendererService.groovy
@@ -69,15 +69,18 @@ class GrailsAdminPluginHtmlRendererService {
     void _renderProperties(object, properties, customWidgets, domainConfig, widgetProperties, builder) {
         properties.each { propertyName ->
             def widget
+            def displayLabel
             if (object != null) {
+                displayLabel = adminConfigHolder.getDisplayLabel(object, propertyName)
                 widget = grailsAdminPluginWidgetService.getWidget(object, propertyName, customWidgets?."$propertyName", widgetProperties)
             } else {
+                displayLabel = adminConfigHolder.getDisplayLabel(domainConfig, propertyName)
                 widget = grailsAdminPluginWidgetService.getWidgetForClass(domainConfig.domainClass, propertyName, customWidgets?."$propertyName", widgetProperties)
             }
 
             builder.div class:"form-group", {
                 label for:"${propertyName.encodeAsHTML()}", {
-                    mkp.yieldUnescaped propertyName.capitalize().encodeAsHTML()
+                    mkp.yieldUnescaped displayLabel.capitalize().encodeAsHTML()
                     if (widget.htmlAttrs.required == 'true') {
                         mkp.yield " *"
                     }
@@ -212,7 +215,8 @@ class GrailsAdminPluginHtmlRendererService {
             if (sortLink) {
                 html.append("<a href='${sortLink}'>")
             }
-            html.append(propertyName)
+            def displayLabel = adminConfigHolder.getDisplayLabel className, propertyName
+            html.append(displayLabel)
             html.append("<span></span>")
             if (sortLink) {
                 html.append("</a>")

--- a/src/groovy/net/kaleidos/plugins/admin/config/AdminConfigHolder.groovy
+++ b/src/groovy/net/kaleidos/plugins/admin/config/AdminConfigHolder.groovy
@@ -44,6 +44,22 @@ class AdminConfigHolder {
         return getDomainConfig(Holders.grailsApplication.getClassForName(objClass))
     }
 
+
+    public String getDisplayLabel(Object objectClass, String propertyName) {
+        def domainClass
+        if (objectClass instanceof String || objectClass instanceof GString) {
+         domainClass = Holders.grailsApplication.getClassForName(objectClass).getSimpleName()
+        }
+        else if (objectClass instanceof DomainConfig) {
+         domainClass = (objectClass as DomainConfig).domainClass.getSimpleName()
+        }
+        else{
+          domainClass = objectClass.class.getSimpleName()
+        }
+        def displayLabel = Holders.config.grails.plugin.admin.label."$domainClass"."$propertyName" ?: propertyName
+        return displayLabel
+    }
+
     public DomainConfig getDomainConfig(Object object) {
         if (!object) {
             return null


### PR DESCRIPTION
I think that it can be good idea to allow user to customize the domain class properties label. For example in my domain class , I have a property codePostal; and I noticed that in the create , edit and list this property is diplayed in uppercase while I prefer that the form display "Code Postal".
   I edit the code for this purpose. User simply add the wanted display name to config file:

```
    grails.plugin.admin.label.DomainClass= [
    property_in_domain_class: String_to_display_in_view
]
```
